### PR TITLE
Support for ruby 1.9 and German Umlaut

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,4 @@
+# coding: UTF-8
 require_dependency 'redmine_percent_done'
 
 Redmine::Plugin.register :redmine_percent_done do

--- a/lib/redmine_percent_done/issue_patch.rb
+++ b/lib/redmine_percent_done/issue_patch.rb
@@ -3,12 +3,21 @@ module RedminePercentDone
 
     def self.apply
       Issue.class_eval do
-        # using prepend instead of include makes life much easier when you have
-        # to override already existing methods. Death to alias_method_chain!
-        prepend InstanceMethods
+		if RUBY_VERSION >= "2.0"
+			# using prepend instead of include makes life much easier when you have
+			# to override already existing methods. Death to alias_method_chain!
+			prepend InstanceMethods
+		else
+			Issue.send(:include, IssuePatch)
+		end
         before_save :update_done_ratio_for_status
       end unless Issue < InstanceMethods # no need to do this more than once.
     end
+	
+	# for compatiblity reasons (ruby < 2.0 does not support prepend)
+	def self.included(base)
+		base.send(:include, InstanceMethods) 
+	end
 
     module InstanceMethods
       def update_done_ratio_for_status


### PR DESCRIPTION
Hi,
I modified the init.rb to support german umlaut with ruby 1.9 (Default is US-ASCII). Some modification were needed as well in issue_patch.rb as ruby < 2.0  does not support the really nice and awesome prepend Feature! :( 
I checked the functionality with my running instances. 
Also I checked with travis - but against ruby  1.9.3 it fails because of some Gemfile problems.

Reasons:
ruby 1.9.3 is still Default in Debian old stable (wheezy) which is often used with some old Redmine installations.

lg
Braini
